### PR TITLE
add example for sending with Node over a LAN

### DIFF
--- a/node-over-a-LAN/README.md
+++ b/node-over-a-LAN/README.md
@@ -1,0 +1,6 @@
+### sending UDP over a LAN ###
+
+The main difference when sending between multiple computers over a LAN is that the "localAddress" property of each computer must use that computer's network address, **not** "127.0.0.1" or "localhost" or any other normal equivalent.
+
+Run these simple examples on two machines over a LAN, substituting actual network names for the demo names "computerA.local" and "compuberB.local".
+

--- a/node-over-a-LAN/receiver.js
+++ b/node-over-a-LAN/receiver.js
@@ -2,14 +2,14 @@
 This example shows sending UDP over a LAN between two machines with the network names computerA and computerB.
 
 The main difference when sending over a LAN is that you can't use 127.0.0.1 or "localhost" in the "localAddress" property - 
-you need to use the computer's own LAN address.
+you need to use the computer's own network address, or 0.0.0.0
 */
 
 //This is computerB, receiving OSC from computerA...
 
 var osc = require("osc");
 var udp = new osc.UDPPort({
-    localAddress: "computerB.local",
+    localAddress: "computerB.local", // could also use 0.0.0.0
     localPort: 9999
 });
 

--- a/node-over-a-LAN/receiver.js
+++ b/node-over-a-LAN/receiver.js
@@ -1,0 +1,24 @@
+/*
+This example shows sending UDP over a LAN between two machines with the network names computerA and computerB.
+
+The main difference when sending over a LAN is that you can't use 127.0.0.1 or "localhost" in the "localAddress" property - 
+you need to use the computer's own LAN address.
+*/
+
+//This is computerB, receiving OSC from computerA...
+
+var osc = require("osc");
+var udp = new osc.UDPPort({
+    localAddress: "computerB.local",
+    localPort: 9999
+});
+
+udp.open();
+
+udp.on("ready", function () {
+    console.log("receiver is ready");
+});
+
+udp.on("message", function(message, timetag, info) {
+   console.log(message); 
+});

--- a/node-over-a-LAN/sender.js
+++ b/node-over-a-LAN/sender.js
@@ -1,10 +1,9 @@
 /*
 This example supposed two machines on a local network with the network names computerA and computerB.
 
-The main thing about sending over a LAN is that you can't use 127.0.0.1 or localhost as your local address - you must use your LAN address.
+The main thing about sending over a LAN is that you can't use 127.0.0.1 or "localhost" as your local address - 
+you must use your LAN address.
 */
-
-
 
 //Set up computerA to send to computerB...
 

--- a/node-over-a-LAN/sender.js
+++ b/node-over-a-LAN/sender.js
@@ -1,0 +1,35 @@
+/*
+This example supposed two machines on a local network with the network names computerA and computerB.
+
+The main thing about sending over a LAN is that you can't use 127.0.0.1 or localhost as your local address - you must use your LAN address.
+*/
+
+
+
+//Set up computerA to send to computerB...
+
+var osc = require("osc");
+
+var udp = new osc.UDPPort({
+    localAddress: "computerA.local", // you can't use localhost if sending over a LAN!
+    localPort: 5000,
+    remoteAddress: "computerB.local",
+    remotePort: 9999
+});
+
+udp.open();
+
+udp.on("ready", function () {
+
+    console.log("ready");
+    
+    setInterval(function () {
+        console.log("sending osc...");
+        udp.send({
+            address: "/sending/every/second",
+            args: [1, 2, 3]
+        })
+    }, 1000);
+});
+
+

--- a/node-over-a-LAN/sender.js
+++ b/node-over-a-LAN/sender.js
@@ -2,7 +2,7 @@
 This example supposed two machines on a local network with the network names computerA and computerB.
 
 The main thing about sending over a LAN is that you can't use 127.0.0.1 or "localhost" as your local address - 
-you must use your LAN address.
+you can use your network address or 0.0.0.0.
 */
 
 //Set up computerA to send to computerB...
@@ -10,7 +10,7 @@ you must use your LAN address.
 var osc = require("osc");
 
 var udp = new osc.UDPPort({
-    localAddress: "computerA.local", // you can't use localhost if sending over a LAN!
+    localAddress: "computerA.local", // could also use 0.0.0.0
     localPort: 5000,
     remoteAddress: "computerB.local",
     remotePort: 9999


### PR DESCRIPTION
This adds a simple example illustrating what's needed to send over a LAN using osc.js.